### PR TITLE
feat: adding a basic clustering example

### DIFF
--- a/pages/_example-clustering/controller.js
+++ b/pages/_example-clustering/controller.js
@@ -1,0 +1,17 @@
+const  { getMapAccessToken } = require('../../services/get-map-token')
+
+const getExampleClusteringPage = async (req, res) => {
+    try {
+        const mapAccessToken = await getMapAccessToken();
+        res.render('_example-clustering/view.njk', {
+            title: 'Example Clustering',
+            pageTitle: 'Example of a basic clustering implementation',
+            mapAccessToken
+        });
+    } catch (error) {
+        console.error('Error rendering page:', error);
+        res.status(500)
+    }
+}
+
+module.exports = { getExampleClusteringPage }

--- a/pages/_example-clustering/view.njk
+++ b/pages/_example-clustering/view.njk
@@ -1,0 +1,81 @@
+{% extends "layouts/main.njk" %}
+
+
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+    <h1 class="mb-4">{{ pageTitle }}</h1>
+
+    {% if mapAccessToken %}
+
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+              integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+              crossorigin=""/>
+        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+                integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+                crossorigin=""></script>
+
+        <style>
+            body {
+                margin:0; padding:0;
+            }
+            #os-map {
+                height:75%;
+            }
+        </style>
+
+
+        <div id="example-map" class="example-map__container">
+            <div id="os-map"></div>
+        </div>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.1.0/dist/MarkerCluster.css"></link>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.1.0/dist/MarkerCluster.Default.css"></link>
+        <script src="https://unpkg.com/leaflet.markercluster@1.1.0/dist/leaflet.markercluster-src.js"></script>
+        <script>
+            const mapAccessToken = '{{ mapAccessToken }}';
+
+            const mapOptions = {
+                minZoom: 7,
+                maxZoom: 20,
+                center: [51.450,-2.587],
+                zoom: 17,
+                maxBounds: [
+                    [ 49.528423, -10.76418 ],
+                    [ 61.331151, 1.9134116 ]
+                ],
+                attributionControl: false
+            };
+
+            const map = L.map('os-map', mapOptions);
+
+            const basemap = L.tileLayer('/api/map-tile/{z}/{x}/{y}', {
+                maxZoom: 20,
+                tileSize: 256
+            }).addTo(map);
+
+            const pinLocations = [
+                { lat: 51.450, lng: -2.586, popup: "Pin 1" },
+                { lat: 51.450, lng: -2.587, popup: "Pin 2" },
+                { lat: 51.450, lng: -2.59, popup: "Pin 3" }
+            ];
+
+            // Add markers to the map
+            var markers = L.markerClusterGroup();
+            markers.addLayer(L.marker([51.450, -2.586]).bindPopup("Pin 1"));
+            markers.addLayer(L.marker([51.450, -2.587]).bindPopup("Pin 2"));
+            markers.addLayer(L.marker([51.450, -2.59]).bindPopup("Pin 3"));
+            markers.addLayer(L.marker([51.550, -2.99]).bindPopup("Pin 4"));
+            markers.addLayer(L.marker([51.350, -2.29]).bindPopup("Pin 5"));
+            markers.addLayer(L.marker([51.250, -2.49]).bindPopup("Pin 6"));
+            markers.addLayer(L.marker([51.850, -2.09]).bindPopup("Pin 7"));
+            markers.addLayer(L.marker([51.050, -2.19]).bindPopup("Pin 8"));
+            markers.addLayer(L.marker([51.150, -2.80]).bindPopup("Pin 9"));
+            markers.addLayer(L.marker([51.450, -2.69]).bindPopup("Pin 10"));
+            markers.addLayer(L.marker([51.250, -2.29]).bindPopup("Pin 11"));
+
+            map.addLayer(markers);
+
+        </script>
+    {% endif %}
+{% endblock %}

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,6 +2,7 @@
 const express = require('express')
 const { getHomePage } = require('../pages/_index/controller');
 const { getExamplePage } = require('../pages/_example/controller');
+const { getExampleClusteringPage } = require('../pages/_example-clustering/controller');
 const { getMapTile } = require('../services/get-map-tile')
 const router = express.Router()
 
@@ -13,6 +14,8 @@ router.get('/', getHomePage)
 router.get('/api/map-tile/:z/:x/:y', getMapTile);
 
 router.get('/example', getExamplePage)
+
+router.get('/example-clustering', getExampleClusteringPage)
 
 router.get('/project-outline',  (req, res) => {
     res.send('Outline prototype goes here')


### PR DESCRIPTION
Using default behaviour of https://github.com/Leaflet/Leaflet.markercluster/tree/master

It has various options which could be explored, including adding our own icons and controlling how many need to be combined to change the colour (default is 10 and 100) and the level of zoom on click.

As this is an example the displayed points are just hard coded

Screenshot:
![image](https://github.com/user-attachments/assets/4eb31613-df94-4e87-99ce-09393338d60b)
